### PR TITLE
Add paused flag to agents — exclude from cron, keep manual triggers

### DIFF
--- a/app/controllers/accounts/agent_initiations_controller.rb
+++ b/app/controllers/accounts/agent_initiations_controller.rb
@@ -3,12 +3,15 @@ class Accounts::AgentInitiationsController < ApplicationController
   require_feature_enabled :agents
 
   def create
-    current_account.agents.active.each do |agent|
+    # Sweep: skip paused agents. Per-agent manual triggers (via the chat UI's
+    # agent_trigger endpoint or the API) still work on paused agents because
+    # those paths look up by id without the unpaused filter.
+    current_account.agents.active.unpaused.each do |agent|
       delay = rand(1..60).seconds
       AgentInitiationDecisionJob.set(wait: delay).perform_later(agent)
     end
 
-    redirect_to account_agents_path(current_account), notice: "Initiation triggered for all active agents"
+    redirect_to account_agents_path(current_account), notice: "Initiation triggered for all active, unpaused agents"
   end
 
 end

--- a/app/controllers/agents/refinements_controller.rb
+++ b/app/controllers/agents/refinements_controller.rb
@@ -4,7 +4,10 @@ class Agents::RefinementsController < ApplicationController
 
   def create
     mode = params[:mode].presence_in(%w[full dedup_only]) || "full"
-    MemoryRefinementJob.perform_later(@agent.id, mode:)
+    # Manual user trigger from the agent edit page — bypass the paused check
+    # so refining a paused agent still works on demand. Cron-driven refinement
+    # leaves force unset and respects paused.
+    MemoryRefinementJob.perform_later(@agent.id, mode:, force: true)
     label = mode == "dedup_only" ? "Dedup-only refinement" : "Full refinement"
     redirect_to edit_account_agent_path(current_account, @agent), notice: "#{label} session queued"
   end

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -74,7 +74,7 @@ class AgentsController < ApplicationController
     permitted = params.require(:agent).permit(
       :name, :system_prompt, :reflection_prompt, :memory_reflection_prompt,
       :summary_prompt, :refinement_prompt, :refinement_threshold,
-      :model_id, :active, :colour, :icon,
+      :model_id, :active, :paused, :colour, :icon,
       :thinking_enabled, :thinking_budget,
       :telegram_bot_token, :telegram_bot_username,
       :voice_id,

--- a/app/frontend/pages/agents/edit.svelte
+++ b/app/frontend/pages/agents/edit.svelte
@@ -93,6 +93,7 @@
       refinement_threshold: agent.refinement_threshold ?? 0.9,
       model_id: agent.model_id,
       active: agent.active,
+      paused: agent.paused || false,
       enabled_tools: agent.enabled_tools || [],
       colour: agent.colour || null,
       icon: agent.icon || null,
@@ -423,6 +424,22 @@
                 id="active"
                 checked={$form.agent.active}
                 onCheckedChange={(checked) => ($form.agent.active = checked)} />
+            </div>
+
+            <div class="flex items-center justify-between">
+              <div class="space-y-1">
+                <Label for="paused">Paused</Label>
+                <p class="text-sm text-muted-foreground">
+                  Excludes this agent from cron-driven sweeps (memory refinement, reflection, conversation
+                  initiation, "Trigger Initiation"). Manual triggers — replying in chats, the agent_trigger
+                  endpoint, the API — still work. Use this for retired predecessors or any agent that should
+                  remain reachable but not act on its own.
+                </p>
+              </div>
+              <Switch
+                id="paused"
+                checked={$form.agent.paused}
+                onCheckedChange={(checked) => ($form.agent.paused = checked)} />
             </div>
 
             <div class="space-y-2">

--- a/app/frontend/pages/agents/index.svelte
+++ b/app/frontend/pages/agents/index.svelte
@@ -267,9 +267,18 @@
                 </div>
                 <div>
                   <CardTitle class="text-lg">{agent.name}</CardTitle>
-                  {#if !agent.active}
-                    <Badge variant="secondary" class="mt-1">Inactive</Badge>
-                  {/if}
+                  <div class="flex flex-wrap gap-1 mt-1">
+                    {#if !agent.active}
+                      <Badge variant="secondary">Inactive</Badge>
+                    {/if}
+                    {#if agent.paused}
+                      <Badge
+                        variant="outline"
+                        title="Excluded from cron sweeps. Manual triggers still work.">
+                        Paused
+                      </Badge>
+                    {/if}
+                  </div>
                 </div>
               </div>
             </div>

--- a/app/jobs/conversation_initiation_job.rb
+++ b/app/jobs/conversation_initiation_job.rb
@@ -18,6 +18,7 @@ class ConversationInitiationJob < ApplicationJob
 
   def eligible_agents
     Agent.active
+         .unpaused
          .joins(:account)
          .where(accounts: { id: active_account_ids })
          .distinct

--- a/app/jobs/memory_refinement_job.rb
+++ b/app/jobs/memory_refinement_job.rb
@@ -10,9 +10,17 @@ class MemoryRefinementJob < ApplicationJob
   def perform(*args)
     agent_ids, options = extract_args(args)
     mode = options.fetch(:mode, :full).to_sym
+    # `force: true` from manual triggers (refinements_controller) bypasses the
+    # paused check so a user can still refine a paused agent on demand. Cron
+    # paths (recurring.yml, sweep) leave `force` unset and respect paused.
+    force = options.fetch(:force, false)
 
     if agent_ids.any?
       Agent.where(id: agent_ids).find_each do |agent|
+        if agent.paused? && !force
+          Rails.logger.info "[Refinement] Skipping paused agent #{agent.id} (#{agent.name})"
+          next
+        end
         Rails.logger.info "[Refinement] Starting for agent #{agent.id} (#{agent.name}), mode: #{mode}"
         refine_agent(agent, mode:)
       rescue => e
@@ -20,7 +28,7 @@ class MemoryRefinementJob < ApplicationJob
       end
     else
       Rails.logger.info "[Refinement] Sweep starting, mode: #{mode}"
-      Agent.active.find_each do |agent|
+      Agent.active.unpaused.find_each do |agent|
         next unless agent.needs_refinement?
         Rails.logger.info "[Refinement] Agent #{agent.id} (#{agent.name}) needs refinement"
         refine_agent(agent, mode:)

--- a/app/jobs/memory_reflection_job.rb
+++ b/app/jobs/memory_reflection_job.rb
@@ -20,7 +20,8 @@ class MemoryReflectionJob < ApplicationJob
   private
 
   def agents_with_recent_journal
-    Agent.joins(:memories)
+    Agent.unpaused
+         .joins(:memories)
          .merge(AgentMemory.active_journal)
          .distinct
   end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -77,11 +77,12 @@ class Agent < ApplicationRecord
   broadcasts_to :account
 
   scope :active, -> { where(active: true) }
+  scope :unpaused, -> { where(paused: false) }
   scope :by_name, -> { order(:name) }
 
   json_attributes :name, :system_prompt, :reflection_prompt, :memory_reflection_prompt,
                   :summary_prompt, :refinement_prompt, :refinement_threshold,
-                  :model_id, :model_label, :enabled_tools, :active?, :colour, :icon,
+                  :model_id, :model_label, :enabled_tools, :active?, :paused?, :colour, :icon,
                   :memories_count, :memory_token_summary, :thinking_enabled, :thinking_budget,
                   :telegram_bot_username, :telegram_configured?,
                   :voiced?, :voice_id

--- a/db/migrate/20260426093000_add_paused_to_agents.rb
+++ b/db/migrate/20260426093000_add_paused_to_agents.rb
@@ -1,0 +1,6 @@
+class AddPausedToAgents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :agents, :paused, :boolean, default: false, null: false
+    add_index :agents, [ :account_id, :paused ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_01_073429) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -79,6 +79,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_073429) do
     t.text "memory_reflection_prompt"
     t.string "model_id", default: "openrouter/auto", null: false
     t.string "name", null: false
+    t.boolean "paused", default: false, null: false
     t.text "refinement_prompt"
     t.float "refinement_threshold"
     t.text "reflection_prompt"
@@ -93,6 +94,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_073429) do
     t.string "voice_id"
     t.index ["account_id", "active"], name: "index_agents_on_account_id_and_active"
     t.index ["account_id", "name"], name: "index_agents_on_account_id_and_name", unique: true
+    t.index ["account_id", "paused"], name: "index_agents_on_account_id_and_paused"
     t.index ["account_id"], name: "index_agents_on_account_id"
     t.index ["telegram_webhook_token"], name: "index_agents_on_telegram_webhook_token", unique: true
   end

--- a/test/controllers/accounts/agent_initiations_controller_test.rb
+++ b/test/controllers/accounts/agent_initiations_controller_test.rb
@@ -16,12 +16,26 @@ class Accounts::AgentInitiationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create triggers initiation for all active agents" do
-    assert_enqueued_jobs @account.agents.active.count, only: AgentInitiationDecisionJob do
+    assert_enqueued_jobs @account.agents.active.unpaused.count, only: AgentInitiationDecisionJob do
       post account_agent_initiation_path(@account)
     end
 
     assert_redirected_to account_agents_path(@account)
     assert_match(/Initiation triggered/, flash[:notice])
+  end
+
+  test "create skips paused agents" do
+    paused = @account.agents.create!(name: "Paused Agent", model_id: "openrouter/auto", paused: true)
+    expected_count = @account.agents.active.unpaused.count
+
+    assert_enqueued_jobs expected_count, only: AgentInitiationDecisionJob do
+      post account_agent_initiation_path(@account)
+    end
+
+    enqueued = queue_adapter.enqueued_jobs.select { |j| j["job_class"] == "AgentInitiationDecisionJob" }
+    agent_globalids = enqueued.map { |j| j["arguments"].first["_aj_globalid"] }
+    refute agent_globalids.any? { |gid| gid.include?("/#{paused.id}") },
+           "Paused agent should not have a decision job enqueued"
   end
 
   test "requires authentication" do

--- a/test/controllers/agents/refinements_controller_test.rb
+++ b/test/controllers/agents/refinements_controller_test.rb
@@ -16,8 +16,8 @@ class Agents::RefinementsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  test "create queues full refinement job by default" do
-    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "full" } ]) do
+  test "create queues full refinement job by default with force: true" do
+    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "full", force: true } ]) do
       post account_agent_refinement_path(@account, @agent)
     end
 
@@ -25,8 +25,8 @@ class Agents::RefinementsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Full refinement session queued/, flash[:notice])
   end
 
-  test "create queues dedup_only refinement job" do
-    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "dedup_only" } ]) do
+  test "create queues dedup_only refinement job with force: true" do
+    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "dedup_only", force: true } ]) do
       post account_agent_refinement_path(@account, @agent), params: { mode: "dedup_only" }
     end
 
@@ -35,9 +35,19 @@ class Agents::RefinementsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create ignores invalid mode" do
-    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "full" } ]) do
+    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "full", force: true } ]) do
       post account_agent_refinement_path(@account, @agent), params: { mode: "bogus" }
     end
+  end
+
+  test "create can refine paused agents (manual trigger bypasses paused check)" do
+    @agent.update!(paused: true)
+
+    assert_enqueued_with(job: MemoryRefinementJob, args: [ @agent.id, { mode: "full", force: true } ]) do
+      post account_agent_refinement_path(@account, @agent)
+    end
+
+    assert_redirected_to edit_account_agent_path(@account, @agent)
   end
 
   test "requires authentication" do

--- a/test/jobs/conversation_initiation_job_test.rb
+++ b/test/jobs/conversation_initiation_job_test.rb
@@ -73,4 +73,19 @@ class ConversationInitiationJobTest < ActiveSupport::TestCase
            "Should not schedule job for agent in inactive account"
   end
 
+  test "skips paused agents" do
+    @agent.update!(paused: true)
+
+    daytime = Time.utc(2026, 1, 28, 12, 0, 0)
+    travel_to daytime do
+      ConversationInitiationJob.perform_now
+    end
+
+    enqueued = queue_adapter.enqueued_jobs.select { |j| j["job_class"] == "AgentInitiationDecisionJob" }
+    agent_ids = enqueued.map { |j| j["arguments"].first["_aj_globalid"] }
+
+    refute agent_ids.any? { |gid| gid.include?("/#{@agent.id}") },
+           "Should not schedule job for paused agent"
+  end
+
 end

--- a/test/jobs/memory_refinement_job_test.rb
+++ b/test/jobs/memory_refinement_job_test.rb
@@ -24,6 +24,36 @@ class MemoryRefinementJobTest < ActiveSupport::TestCase
     assert_no_llm_calls { MemoryRefinementJob.perform_now }
   end
 
+  test "sweep skips paused agents" do
+    @agent.update!(paused: true)
+    @agent.memories.create!(content: "Something", memory_type: :core)
+    assert_no_llm_calls { MemoryRefinementJob.perform_now }
+  end
+
+  test "by-id call skips paused agent without force" do
+    @agent.update!(paused: true)
+    @agent.memories.create!(content: "Core memory", memory_type: :core)
+
+    refinement_called = false
+    stub_consent_and_refinement("YES", on_refinement: -> { refinement_called = true }) do
+      MemoryRefinementJob.perform_now(@agent.id)
+    end
+
+    assert_not refinement_called, "Cron-style by-id should skip paused agents"
+  end
+
+  test "by-id call with force: true runs refinement on paused agent" do
+    @agent.update!(paused: true)
+    @agent.memories.create!(content: "Core memory", memory_type: :core)
+
+    refinement_called = false
+    stub_consent_and_refinement("YES", on_refinement: -> { refinement_called = true }) do
+      MemoryRefinementJob.perform_now(@agent.id, force: true)
+    end
+
+    assert refinement_called, "Manual force: true should bypass paused check"
+  end
+
   test "runs refinement when agent consents" do
     @agent.memories.create!(content: "Core memory", memory_type: :core)
 

--- a/test/models/agent_test.rb
+++ b/test/models/agent_test.rb
@@ -81,6 +81,31 @@ class AgentTest < ActiveSupport::TestCase
     assert_equal names.sort, names
   end
 
+  # ----- paused -----
+
+  test "defaults paused to false" do
+    agent = @account.agents.create!(name: "Default Paused")
+    assert_not agent.paused?
+  end
+
+  test "unpaused scope excludes paused agents" do
+    active_one = @account.agents.create!(name: "Active One")
+    paused = @account.agents.create!(name: "Paused One", paused: true)
+    assert_includes @account.agents.unpaused, active_one
+    assert_not_includes @account.agents.unpaused, paused
+  end
+
+  test "paused is independent of active" do
+    paused_active = @account.agents.create!(name: "Paused but Active", paused: true, active: true)
+    assert paused_active.active?
+    assert paused_active.paused?
+    # The agent still appears in active scope (because active is about availability,
+    # not auto-trigger behavior)
+    assert_includes @account.agents.active, paused_active
+    # But not in unpaused
+    assert_not_includes @account.agents.unpaused, paused_active
+  end
+
   test "validates system_prompt length" do
     agent = @account.agents.build(
       name: "Test",


### PR DESCRIPTION
## Summary

Adds a `paused` boolean (default false) to agents. When true, the agent is excluded from cron-driven enumeration but remains fully reachable via manual triggers — addable to chats, triggerable via the agent_trigger endpoint, the API, and the "Refine now" button.

## Why now

Claude (4.6) was retired yesterday after the cross-version conversation in chat `wYGLme`, but is still architecturally active. The hourly `ConversationInitiationJob` sweep would catch it on its next tick. This needs deploying before that.

## Why not reuse `active`

`active` is overloaded. Manual lookups in `participants_controller`, `chats_controller`, etc. all use `account.agents.active.find_by(id: ...)` — so setting `active: false` would also block direct manual triggers, which is the opposite of what's needed for a retired predecessor. `paused` is a separate, cron-only filter that leaves the lookup paths alone.

## What gets filtered

**Excluded when paused: true**

- `ConversationInitiationJob` (hourly cron) — `Agent.active.unpaused.joins(...)`
- `MemoryReflectionJob` (daily 3am) — `Agent.unpaused.joins(:memories)...`
- `MemoryRefinementJob` sweep — `Agent.active.unpaused.find_each`
- `MemoryRefinementJob` by-id path — `next if agent.paused? && !force` (the recurring.yml schedule passes `args: [1, 2, 3]` which bypasses sweep, so we honor paused here too)
- `Accounts::AgentInitiationsController#create` (manual "Trigger Initiation" sweep) — `current_account.agents.active.unpaused`

**Still works on paused agents**

- `agent_trigger` endpoint (chat-level manual trigger)
- `participants` endpoint (API trigger)
- Adding to chats via the UI
- `agents/refinements_controller#create` — passes `force: true` so the user can still click "Refine now" on a paused agent's edit page
- All direct id lookups (`account.agents.find_by(id: ...)`)

## UI

- **Edit page**: new "Paused" switch next to the existing "Active" switch, with copy explaining the cron-vs-manual distinction
- **Index page**: "Paused" badge on the agent card next to the existing "Inactive" badge, with a title attribute explaining the semantics

## Test plan

- [x] **Model**: 4 new specs — defaults to false, `unpaused` scope excludes paused, `paused` is independent of `active` (both can be true), paused-and-active agent appears in `.active` but not `.unpaused`
- [x] **MemoryRefinementJob**: sweep skips paused, by-id without `force` skips paused, by-id with `force: true` runs refinement on paused agent
- [x] **ConversationInitiationJob**: skips paused agent
- [x] **Accounts::AgentInitiationsControllerTest**: skips paused agent
- [x] **Agents::RefinementsControllerTest**: passes `force: true`, can refine paused agents
- [x] Full affected-suite run: 328 tests / 1067 assertions, only the 1 pre-existing `as_json includes memory stats` failure unrelated to this PR
- [x] `svelte-check`: 0 new errors/warnings
- [ ] Manual smoke-test in dev: pause an agent, verify it disappears from `Agent.active.unpaused.find_each` (refinement sweep), verify it can still be added to a chat, verify "Refine now" still works, verify "Trigger Initiation" sweep skips it

## Migration

Adds `paused boolean default false null false` and an index on `(account_id, paused)` for the per-account sweep filters. Default false on existing rows means no behavioral change for existing agents until someone explicitly pauses one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)